### PR TITLE
Fix CMakeLists.txt build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,71 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(restd_library)
+project(restd_library VERSION 0.1.0)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Werror -std=c++0x")
+set(library_SOURCES
+  src/crash_manager.cpp
+  include/crash_manager.h
+  src/http.cpp
+  include/http.h
+  src/http_route.cpp
+  include/http_route.h
+  src/http_server.cpp
+  include/http_server.h
+  src/log.cpp
+  include/log.h
+  src/mutex.cpp
+  include/mutex.h
+  src/strings.cpp
+  include/strings.h
+  src/tcp_server.cpp
+  include/tcp_server.h
+  src/tcp_stream.cpp
+  include/tcp_stream.h
+  src/thread.cpp
+  include/thread.h
+  include/consumer.hpp
+  include/json.hpp
+  include/restd.h
+  include/work_queue.hpp)
 
-file( GLOB library_SOURCES src/*.cpp)
-
-add_library(restd STATIC ${library_SOURCES})
+add_library(restd ${library_SOURCES})
 
 target_include_directories(restd
-    PUBLIC ${PROJECT_SOURCE_DIR}/include
-)
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+
+target_compile_options(restd
+  PRIVATE
+    $<$<CXX_COMPILER_ID:GNU>:-Werror>
+    $<$<CONFIG:DEBUG>:-O1>
+    $<$<CONFIG:RELEASE>:-O3>)
+
+target_compile_features(restd PUBLIC
+  cxx_auto_type)
 
 set(binary_SOURCES
-    hello_world.cpp
-)
+  hello_world.cpp)
 
 add_executable(hello_world ${binary_SOURCES})
 
-target_link_libraries( hello_world
-    PRIVATE restd pthread
-)
+target_link_libraries(hello_world
+    PRIVATE restd Threads::Threads)
+
+export(TARGETS restd FILE cmake/restdConfig.cmake)
+export(PACKAGE restd)
+
+include(GNUInstallDirs)
+install(TARGETS restd EXPORT restdTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(DIRECTORY include DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(cmake/restdConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion)


### PR DESCRIPTION
 - Remove global declarations such as include_directories() and
   substitute with appropriate target_* functions
 - Enable proper packaging and installation of restd
 - Use generator expressions whenever possible
 - Also naming sources explicitly to enable CMake to do proper dependency management