### PR TITLE
Using std::string instead of buffer with fixed size

### DIFF
--- a/include/tcp_stream.h
+++ b/include/tcp_stream.h
@@ -48,7 +48,7 @@ class tcp_stream
 
     ssize_t send(const unsigned char* buffer, size_t len);
     ssize_t receive(unsigned char* buffer, size_t len, int timeout=0);
-    ssize_t read_until(unsigned char until, unsigned char *buffer, size_t len, int timeout);
+    ssize_t read_until(unsigned char until, string& line, int timeout);
 
     string peer_address();
     int    peer_port();

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -42,7 +42,7 @@ void http_consumer::consume( tcp_stream *client ) {
   int           read = 0,
                 left = 0,
                 toread = 0;
-  char          line[0xff] = {0};
+  string        line;
   http_request  request;
   http_response response;
   string        res_buffer;
@@ -62,14 +62,14 @@ void http_consumer::consume( tcp_stream *client ) {
 
   // Read request line by line until the end of headers.
   while( request.parser_state != PARSE_DONE ) {
-    int r = client->read_until( (unsigned char)'\n', (unsigned char *)line, 0xff, http_request::read_timeout );
+    int r = client->read_until( (unsigned char)'\n', line, http_request::read_timeout );
     if( r <= 0 ) {
       LOG_FAILED_READ(r)
       return;
     }
 
     try {
-      if( request.parse_line( (const unsigned char *)line, strlen(line) ) == false ) {
+      if( request.parse_line( (const unsigned char *)line.c_str(), line.length() ) == false ) {
         response.bad_request();
         goto done;
       }

--- a/src/tcp_stream.cpp
+++ b/src/tcp_stream.cpp
@@ -53,24 +53,19 @@ ssize_t tcp_stream::receive(unsigned char* buffer, size_t len, int timeout) {
   return TCP_READ_TIMEOUT;
 }
 
-ssize_t tcp_stream::read_until(unsigned char until, unsigned char *buffer, size_t len, int timeout) {
-  size_t wrote, tot;
+ssize_t tcp_stream::read_until(unsigned char until, string& line, int timeout) {
+  size_t max = 0xFFFF, wrote;
   unsigned char byte = 0;
 
-  // if i include strings.h here, bad things happen, so fuck memset
-  //
-  // memset( buffer, 0x00, len );
-  for( unsigned char *p = buffer; p != buffer + len; ++p ) {
-    *p = 0x00;
-  }
+  line.clear();
 
-  for( wrote = 0, tot = len; len > 0 && wrote < tot && byte != until; --len, wrote++ ) {
+  for( wrote = 0; wrote < max && byte != until; ++wrote ) {
     int r = receive( &byte, 1, timeout );
     if( r != 1 ) {
       return r;
     }
 
-    buffer[wrote] = byte;
+    line += byte;
   }
 
   return wrote;


### PR DESCRIPTION
If the request has lines longer than 0xFF in the request header the server replies with an "Bad Request". Using std::string instead of a buffer with fixed size it could handle request with lines of any size. 

However I left a maximum size to prevent anyone from sending ad hoc requests to saturate resources